### PR TITLE
Fixes #1, ssl protocoll version settings

### DIFF
--- a/productstatus/event.py
+++ b/productstatus/event.py
@@ -66,7 +66,6 @@ class Listener(object):
     @staticmethod
     def create_security_context(verify_ssl=True):
         ctx = ssl_module.create_default_context()
-        ctx.protocol = ssl_module.PROTOCOL_TLSv1_2
         if not verify_ssl:
             ctx.check_hostname = False
             ctx.verify_mode = ssl_module.CERT_NONE

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ config = {
     'url': 'https://github.com/metno/python-productstatus-client',
     'download_url': 'https://github.com/metno/python-productstatus-client',
     'version': '7.0.0',
+    'python_requires': '>=3.6',
     'install_requires': [
         'nose==1.3.7',
         'requests==2.20.0',


### PR DESCRIPTION
The syntax of the SSL library changed for mature verisons of python.
This should work (and is sufficient) for python >=3.6.