### PR TITLE
Dev/3 auto commit setup

### DIFF
--- a/productstatus/event.py
+++ b/productstatus/event.py
@@ -87,19 +87,20 @@ class Listener(object):
         """
         self.json_consumer.close()
 
-    def get_next_event(self, return_kafka_offset=False):
+    def get_next_event(self, return_kafka_topic_offset=False):
         """!
         @brief Block until a message is received, or a timeout is reached, and
         return the message object. Raises an exception if a timeout is reached.
 
-        @param return_kafka_offsett If true, returns offset value on the
-            message in the kafka queue.
+        @param return_kafka_topic_offset If True, returns a dict with
+            {topic, offset} for the message in the kafka queue.
         @returns Message object or (Message object, offset) object.
         """
         try:
             for message in self.json_consumer:
-                if return_kafka_offset:
-                    return Message(message.value), message.offset
+                if return_kafka_topic_offset:
+                    return (Message(message.value),
+                            {message.topic: message.offset})
                 else:
                     return Message(message.value)
         except StopIteration:
@@ -110,6 +111,7 @@ class Listener(object):
         """!
         @brief Store the client's position in the message queue.
 
-        Wrap KafkaConsumer.commit()
+        Wraps KafkaConsumer.commit(). Example usage:
+        `self.save_position({"productstatus", 54})` will commit msg. with offset 54 on the topic `"productstatus"`.
         """
         self.json_consumer.commit(offsets)

--- a/productstatus/event.py
+++ b/productstatus/event.py
@@ -66,7 +66,6 @@ class Listener(object):
     @staticmethod
     def create_security_context(verify_ssl=True):
         ctx = ssl_module.create_default_context()
-        ctx.protocol = ssl_module.PROTOCOL_TLSv1_2
         if not verify_ssl:
             ctx.check_hostname = False
             ctx.verify_mode = ssl_module.CERT_NONE

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ config = {
     'url': 'https://github.com/metno/python-productstatus-client',
     'download_url': 'https://github.com/metno/python-productstatus-client',
     'version': '7.0.0',
+    'python_requires': '>=3.6',
     'install_requires': [
         'nose==1.3.7',
         'requests==2.20.0',


### PR DESCRIPTION
Fixes #3, such that messages can be non-auto committed to kafka.

Note: To test this with python >= 3.6, you have to merge in #2, too. For convenience, this branch was based on #2.